### PR TITLE
set typing for arguments of functions

### DIFF
--- a/template/icon.nunjucks
+++ b/template/icon.nunjucks
@@ -39,7 +39,7 @@ export default class Icon extends React.Component<IconProps, {}> {
         return (<div>{ iconList.map(kind => this.renderPreviewKind(kind)) }</div>)
     }
 
-    renderIcon(kind) {
+    renderIcon(kind: string) {
         const { wrapperStyle } = this.props
         if (wrapperStyle) {
             return (<div style={wrapperStyle}>{ this.getIcon(kind) }</div>)
@@ -47,7 +47,7 @@ export default class Icon extends React.Component<IconProps, {}> {
         return this.getIcon(kind)
     }
 
-    renderPreviewKind(kind) {
+    renderPreviewKind(kind: string) {
         return (
             <div key={kind}>
                 <h3>&lt;Icon kind="{kind}" /&gt;</h3>
@@ -56,7 +56,7 @@ export default class Icon extends React.Component<IconProps, {}> {
         )
     }
 
-    getIcon(kind) {
+    getIcon(kind: string) {
         const { color, height, onClick, size, style, width, className } = this.props
 
         switch (kind) {

--- a/template/icon.nunjucks
+++ b/template/icon.nunjucks
@@ -14,7 +14,7 @@ export interface IconProps {
     color?: string
     className?: string
     height?: number
-    kind?: string
+    kind?: string | any
     onClick?: () => void
     preview?: boolean
     size?: number


### PR DESCRIPTION
I've made this PR to fix `tslint` errors.

Changes:
- Add typings to `renderIcon`, `renderPreviewKind`, `getIcon`